### PR TITLE
ci: grant id-token/contents permissions to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,15 @@ on:
   repository_dispatch:
     types: [ do-release ]
 
+# The reusable release workflow requires id-token: write (RubyGems Trusted
+# Publishing via OIDC). A reusable workflow cannot request more permissions
+# than its caller grants, so these must be declared here or the run fails at
+# startup. Keep in sync with the Cimas template.
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
 jobs:
   release:
     uses: metanorma/ci/.github/workflows/rubygems-release.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.bundle/
+/Gemfile.lock
+/.rspec_status
+/coverage/
+/pkg/
+/tmp/


### PR DESCRIPTION
## Problem

Dispatching the `release` workflow fails immediately with `startup_failure` (before any job step runs), so lutaml-hal can't be released.

## Cause

The reusable workflow `metanorma/ci/.github/workflows/rubygems-release.yml@main` now declares `permissions: id-token: write` (for RubyGems Trusted Publishing via OIDC) — added after this repo last released in July 2025. A reusable workflow **cannot request more permissions than its caller grants**. `release.yml` here declared no `permissions:`, so it inherited the repo default (which never includes `id-token`), and the call exceeded the caller's grant → startup failure.

Other metanorma gems whose `release.yml` already carries this block (e.g. `vectory`) release fine through the same reusable workflow.

## Fix

Add the `permissions:` block the reusable workflow requires:

```yaml
permissions:
  contents: write
  packages: write
  id-token: write
```

The file is Cimas-generated; its template for this repo should be updated to match so this isn't lost on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)