### PR TITLE
Make SimpleCacheStore thread-safe

### DIFF
--- a/lib/lutaml/hal/cache/simple_cache_store.rb
+++ b/lib/lutaml/hal/cache/simple_cache_store.rb
@@ -3,7 +3,11 @@
 module Lutaml
   module Hal
     module Cache
-      # Simple in-memory cache store for testing and fallback scenarios
+      # Simple in-memory cache store for testing and fallback scenarios.
+      #
+      # Thread-safe: a single mutex guards the cache and its LRU bookkeeping so
+      # it can back the register cache when consumers realize links from many
+      # threads (e.g. a parallel fetcher).
       class SimpleCacheStore
         attr_reader :max_size
 
@@ -11,52 +15,63 @@ module Lutaml
           @max_size = max_size
           @cache = {}
           @access_order = []
+          @mutex = Mutex.new
         end
 
         def get(key)
-          return nil unless @cache.key?(key)
+          @mutex.synchronize do
+            return nil unless @cache.key?(key)
 
-          # Update access order for LRU
-          @access_order.delete(key)
-          @access_order.push(key)
+            # Update access order for LRU
+            @access_order.delete(key)
+            @access_order.push(key)
 
-          @cache[key]
+            @cache[key]
+          end
         end
 
         def set(key, value)
-          # Remove existing entry if present
-          if @cache.key?(key)
-            @access_order.delete(key)
-          elsif @cache.size >= @max_size
-            # Evict least recently used item
-            lru_key = @access_order.shift
-            @cache.delete(lru_key)
-          end
+          @mutex.synchronize do
+            # Remove existing entry if present
+            if @cache.key?(key)
+              @access_order.delete(key)
+            elsif @cache.size >= @max_size
+              # Evict least recently used item
+              lru_key = @access_order.shift
+              @cache.delete(lru_key)
+            end
 
-          @cache[key] = value
-          @access_order.push(key)
+            @cache[key] = value
+            @access_order.push(key)
+          end
         end
 
         def delete(key)
-          @access_order.delete(key)
-          @cache.delete(key)
+          @mutex.synchronize do
+            @access_order.delete(key)
+            @cache.delete(key)
+          end
         end
 
         def clear
-          @cache.clear
-          @access_order.clear
+          @mutex.synchronize do
+            @cache.clear
+            @access_order.clear
+          end
         end
 
         def size
-          @cache.size
+          @mutex.synchronize { @cache.size }
         end
 
         def stats
-          {
-            size: @cache.size,
-            max_size: @max_size,
-            keys: @cache.keys
-          }
+          @mutex.synchronize do
+            {
+              size: @cache.size,
+              max_size: @max_size,
+              keys: @cache.keys
+            }
+          end
         end
 
         def cache_info

--- a/spec/lutaml/hal/cache/simple_cache_store_spec.rb
+++ b/spec/lutaml/hal/cache/simple_cache_store_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative '../../../../lib/lutaml/hal/cache/simple_cache_store'
+
+RSpec.describe Lutaml::Hal::Cache::SimpleCacheStore do
+  subject(:store) { described_class.new(3) }
+
+  it 'stores and retrieves values' do
+    store.set('a', 1)
+    expect(store.get('a')).to eq(1)
+    expect(store.get('missing')).to be_nil
+  end
+
+  it 'reports size and deletes/clears' do
+    store.set('a', 1)
+    store.set('b', 2)
+    expect(store.size).to eq(2)
+    store.delete('a')
+    expect(store.get('a')).to be_nil
+    expect(store.size).to eq(1)
+    store.clear
+    expect(store.size).to eq(0)
+  end
+
+  it 'evicts the least-recently-used entry past max_size' do
+    store.set('a', 1)
+    store.set('b', 2)
+    store.set('c', 3)
+    store.get('a')        # 'a' is now most-recently used, 'b' is LRU
+    store.set('d', 4)     # evicts 'b'
+    expect(store.get('b')).to be_nil
+    expect(store.get('a')).to eq(1)
+    expect(store.get('d')).to eq(4)
+    expect(store.size).to eq(3)
+  end
+
+  it 'is safe under concurrent access' do
+    store = described_class.new(50)
+    threads = Array.new(8) do |t|
+      Thread.new do
+        300.times do |i|
+          key = "key#{(i * 7 + t) % 120}"
+          store.set(key, "#{t}-#{i}")
+          store.get(key)
+          store.delete("key#{i % 120}") if i.even?
+        end
+      end
+    end
+
+    expect { threads.each(&:join) }.not_to raise_error
+    # LRU bookkeeping stayed consistent: size never runs away past the cap.
+    expect(store.size).to be <= 50
+    expect(store.stats[:keys].size).to eq(store.size)
+  end
+end


### PR DESCRIPTION
## Problem

`SimpleCacheStore` (the in-memory adapter behind the register cache) uses a hand-rolled LRU — a `@cache` Hash plus an `@access_order` Array manipulated with `delete`/`push`/`shift` — with **no synchronization**.

The register cache is read and written concurrently whenever a consumer realizes links from multiple threads (e.g. relaton-w3c's parallel `DataFetcher` worker pool). Concurrent `set`/`get` can interleave the two-step LRU updates, desyncing `@cache` from `@access_order` (wrong evictions, runaway `@access_order`, lost entries).

## Fix

Guard every operation (`get`/`set`/`delete`/`clear`/`size`/`stats`) with a single `Mutex`. Cheap under MRI and correct under real parallelism.

## Tests

Adds `simple_cache_store_spec.rb`: basic get/set/delete/clear, LRU eviction, and a concurrency exercise (8 threads × 300 ops) asserting no errors and that the size/bookkeeping stay consistent. Full suite: 217 examples, 0 failures; RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)