### PR TITLE
deps: bump lutaml-store to ~> 0.2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Development Commands
 
 ```bash
-bundle install                  # Install dependencies (lutaml-store is a local path dependency)
+bundle install                  # Install dependencies (lutaml-store from rubygems)
 bundle exec rake                # Run specs + rubocop (default task)
 bundle exec rspec               # Run all specs
 bundle exec rspec spec/lutaml/hal/client_spec.rb       # Run a single spec file
@@ -71,7 +71,7 @@ The cache subsystem uses `Lutaml::Store::CacheStore` exclusively for persistence
 ### Dependencies
 
 - `lutaml-model`: serialization framework (Serializable, key_value mappings, attribute definitions)
-- `lutaml-store`: cache store abstraction with TTL, LRU, and multiple adapters (local path dependency at `../lutaml-store`)
+- `lutaml-store` (~> 0.2): cache store abstraction with TTL, LRU, and multiple adapters (memory/filesystem/sqlite)
 - `faraday` + `faraday-follow_redirects`: HTTP client
 
 ### Register ID Propagation

--- a/lutaml-hal.gemspec
+++ b/lutaml-hal.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'faraday-follow_redirects', '~> 0.3'
   spec.add_dependency 'lutaml-model'
-  spec.add_dependency 'lutaml-store', '~> 0.1.1'
+  spec.add_dependency 'lutaml-store', '~> 0.2'
   spec.add_dependency 'rainbow', '~> 3.0'
 end


### PR DESCRIPTION
Bump the lutaml-store constraint from ~> 0.1.1 to ~> 0.2 to allow the 0.2.x series. The 0.1.x constraint blocks all 0.2.x releases including 0.2.2 (latest published) and 0.2.3 (in development).

The 0.2.x line retains backwards-compatible public API used by our CacheManager (CacheStore + Memory/FileSystem/Sqlite adapters). The Memory adapter was rewritten with snapshot-based reads in 0.2.3, but the CacheStore interface is unchanged.

Updates CLAUDE.md to reflect the new dependency source (rubygems, not local path).

Verified: 178 examples, 0 failures against lutaml-store 0.2.2.